### PR TITLE
Zoom issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 jacksonCSVVersion=2.13.4
 jacksonModuleKotlinVersion=2.13.2
-virtualizedfxVersion=11.9.0
+virtualizedfxVersion=11.9.1
 tornadofxVersion=2.0.0-SNAPSHOT
 coroutinesVersion=1.6.4
 controlsfxVersion=11.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 jacksonCSVVersion=2.13.4
 jacksonModuleKotlinVersion=2.13.2
-virtualizedfxVersion=11.8.5
+virtualizedfxVersion=11.9.0
 tornadofxVersion=2.0.0-SNAPSHOT
 coroutinesVersion=1.6.4
 controlsfxVersion=11.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 jacksonCSVVersion=2.13.4
 jacksonModuleKotlinVersion=2.13.2
-virtualizedfxVersion=11.9.1
+virtualizedfxVersion=11.9.3
 tornadofxVersion=2.0.0-SNAPSHOT
 coroutinesVersion=1.6.4
 controlsfxVersion=11.1.2

--- a/src/main/kotlin/solve/scene/controller/SceneController.kt
+++ b/src/main/kotlin/solve/scene/controller/SceneController.kt
@@ -3,6 +3,7 @@ package solve.scene.controller
 import javafx.beans.property.SimpleDoubleProperty
 import javafx.beans.property.SimpleObjectProperty
 import solve.scene.model.Scene
+import solve.scene.view.DelayedFrameUpdatesManager
 import solve.scene.view.SceneView
 import solve.utils.ceilToInt
 import solve.utils.structures.DoublePoint
@@ -66,10 +67,12 @@ class SceneController : Controller() {
         val initialMouseX = (xProperty.value + mousePosition.x) / scaleProperty.value
         val initialMouseY = (yProperty.value + mousePosition.y) / scaleProperty.value
 
-        scaleProperty.value = newScale
+        DelayedFrameUpdatesManager.doLockedAction {
+            scaleProperty.value = newScale
 
-        x = initialMouseX * scaleProperty.value - mousePosition.x
-        y = initialMouseY * scaleProperty.value - mousePosition.y
+            x = initialMouseX * scaleProperty.value - mousePosition.x
+            y = initialMouseY * scaleProperty.value - mousePosition.y
+        }
     }
 
     companion object {

--- a/src/main/kotlin/solve/scene/view/DelayedFrameUpdatesManager.kt
+++ b/src/main/kotlin/solve/scene/view/DelayedFrameUpdatesManager.kt
@@ -1,0 +1,24 @@
+package solve.scene.view
+
+import solve.scene.model.VisualizationFrame
+
+object DelayedFrameUpdatesManager {
+    private val delayedUpdates = mutableMapOf<FrameView, VisualizationFrame?>()
+
+    var shouldDelay = false
+        private set
+
+    fun doLockedAction(action: () -> Unit) {
+        shouldDelay = true
+        action()
+        shouldDelay = false
+        delayedUpdates.forEach { (view, newFrame) ->
+            view.setFrame(newFrame)
+        }
+        delayedUpdates.clear()
+    }
+
+    fun delayUpdate(view: FrameView, newFrame: VisualizationFrame?) {
+        delayedUpdates[view] = newFrame
+    }
+}

--- a/src/main/kotlin/solve/scene/view/FrameView.kt
+++ b/src/main/kotlin/solve/scene/view/FrameView.kt
@@ -104,7 +104,11 @@ class FrameView(
     }
 
     fun setFrame(frame: VisualizationFrame?) {
-        if (frame?.timestamp == currentFrame?.timestamp) {
+        if (DelayedFrameUpdatesManager.shouldDelay) {
+            DelayedFrameUpdatesManager.delayUpdate(this, frame)
+            return
+        }
+        if (frame == currentFrame) {
             return
         }
         currentJob?.cancel()

--- a/src/main/kotlin/solve/scene/view/FrameView.kt
+++ b/src/main/kotlin/solve/scene/view/FrameView.kt
@@ -104,6 +104,9 @@ class FrameView(
     }
 
     fun setFrame(frame: VisualizationFrame?) {
+        if (frame?.timestamp == currentFrame?.timestamp) {
+            return
+        }
         currentJob?.cancel()
         disposeLandmarkViews()
         removeLandmarksNodes()

--- a/src/main/kotlin/solve/scene/view/virtualizedfx/VirtualizedFXGrid.kt
+++ b/src/main/kotlin/solve/scene/view/virtualizedfx/VirtualizedFXGrid.kt
@@ -32,6 +32,9 @@ class VirtualizedFXGrid(
     override val yProperty = SimpleDoubleProperty(virtualGrid.position.y)
 
     private val scaleChangedListener = InvalidationListener {
+        // Virtual grid can't lay out columns correctly if position differs from (0, 0)
+        scrollX(0.0)
+        scrollY(0.0)
         val newScale = scaleProperty.value
         virtualGrid.cellSize = Size(cellSize.width * newScale, cellSize.height * newScale)
     }

--- a/src/main/kotlin/solve/scene/view/virtualizedfx/VirtualizedFXGrid.kt
+++ b/src/main/kotlin/solve/scene/view/virtualizedfx/VirtualizedFXGrid.kt
@@ -32,10 +32,6 @@ class VirtualizedFXGrid(
     override val yProperty = SimpleDoubleProperty(virtualGrid.position.y)
 
     private val scaleChangedListener = InvalidationListener {
-        // Virtual grid breaks if cell size changes when x position differs from 0.0
-        // Virtual grid always drops position to (0, 0) when cell size changes, so this solution is ok
-        scrollX(0.0)
-        scrollY(0.0)
         val newScale = scaleProperty.value
         virtualGrid.cellSize = Size(cellSize.width * newScale, cellSize.height * newScale)
     }

--- a/src/main/kotlin/solve/scene/view/virtualizedfx/VirtualizedFXGridProvider.kt
+++ b/src/main/kotlin/solve/scene/view/virtualizedfx/VirtualizedFXGridProvider.kt
@@ -2,6 +2,7 @@ package solve.scene.view.virtualizedfx
 
 import io.github.palexdev.mfxcore.base.beans.Size
 import io.github.palexdev.mfxcore.collections.ObservableGrid
+import io.github.palexdev.virtualizedfx.cell.GridCell
 import io.github.palexdev.virtualizedfx.grid.VirtualGrid
 import io.github.palexdev.virtualizedfx.utils.VSPUtils
 import javafx.beans.property.DoubleProperty
@@ -11,6 +12,20 @@ import solve.scene.view.Grid
 import solve.scene.view.GridProvider
 import solve.scene.view.association.OutOfFramesLayer
 import solve.utils.structures.Size as DoubleSize
+
+class ZoomableVirtualGrid<T, C : GridCell<T>>(items: ObservableGrid<T>, cellFactory: (T) -> C) :
+    VirtualGrid<T, C>(items, cellFactory) {
+    override fun onCellSizeChanged() {
+        val helper = gridHelper
+        helper.computeEstimatedSize()
+
+        if (width != 0.0 && height != 0.0) {
+            if (!viewportManager.init()) {
+                requestViewportLayout()
+            }
+        }
+    }
+}
 
 object VirtualizedFXGridProvider : GridProvider {
     override fun createGrid(
@@ -22,7 +37,7 @@ object VirtualizedFXGridProvider : GridProvider {
         cellFactory: (VisualizationFrame?) -> FrameView
     ): Grid {
         val gridData = ObservableGrid.fromList(data, columnsNumber)
-        val grid = VirtualGrid(gridData) { item -> FrameViewAdapter(cellFactory(item)) }
+        val grid = ZoomableVirtualGrid(gridData) { item -> FrameViewAdapter(cellFactory(item)) }
         grid.cellSize = Size(cellSize.width * scale.value, cellSize.height * scale.value)
         grid.prefHeight = Int.MAX_VALUE.toDouble()
 

--- a/src/main/kotlin/solve/scene/view/virtualizedfx/VirtualizedFXGridProvider.kt
+++ b/src/main/kotlin/solve/scene/view/virtualizedfx/VirtualizedFXGridProvider.kt
@@ -2,7 +2,6 @@ package solve.scene.view.virtualizedfx
 
 import io.github.palexdev.mfxcore.base.beans.Size
 import io.github.palexdev.mfxcore.collections.ObservableGrid
-import io.github.palexdev.virtualizedfx.cell.GridCell
 import io.github.palexdev.virtualizedfx.grid.VirtualGrid
 import io.github.palexdev.virtualizedfx.utils.VSPUtils
 import javafx.beans.property.DoubleProperty
@@ -12,20 +11,6 @@ import solve.scene.view.Grid
 import solve.scene.view.GridProvider
 import solve.scene.view.association.OutOfFramesLayer
 import solve.utils.structures.Size as DoubleSize
-
-class ZoomableVirtualGrid<T, C : GridCell<T>>(items: ObservableGrid<T>, cellFactory: (T) -> C) :
-    VirtualGrid<T, C>(items, cellFactory) {
-    override fun onCellSizeChanged() {
-        val helper = gridHelper
-        helper.computeEstimatedSize()
-
-        if (width != 0.0 && height != 0.0) {
-            if (!viewportManager.init()) {
-                requestViewportLayout()
-            }
-        }
-    }
-}
 
 object VirtualizedFXGridProvider : GridProvider {
     override fun createGrid(
@@ -37,7 +22,7 @@ object VirtualizedFXGridProvider : GridProvider {
         cellFactory: (VisualizationFrame?) -> FrameView
     ): Grid {
         val gridData = ObservableGrid.fromList(data, columnsNumber)
-        val grid = ZoomableVirtualGrid(gridData) { item -> FrameViewAdapter(cellFactory(item)) }
+        val grid = VirtualGrid(gridData) { item -> FrameViewAdapter(cellFactory(item)) }
         grid.cellSize = Size(cellSize.width * scale.value, cellSize.height * scale.value)
         grid.prefHeight = Int.MAX_VALUE.toDouble()
 


### PR DESCRIPTION
Librarian component VirtualGrid doesn't support zooming out of the box, it should drop scroll position when cell size was changed. The solution to bypass redundant frame updates is to delay all updates to the moment when final after zooming configuration is reached.

Average FPS on zooming at the center position (from min scale to max and back):
Before fix: 3.61497468
After fix: 13.9524014