### PR TITLE
Keyboard navigation and shortcuts

### DIFF
--- a/src/main/kotlin/solve/catalogue/view/CatalogueView.kt
+++ b/src/main/kotlin/solve/catalogue/view/CatalogueView.kt
@@ -3,6 +3,8 @@ package solve.catalogue.view
 import javafx.collections.FXCollections
 import javafx.geometry.Insets
 import javafx.geometry.Pos
+import javafx.scene.input.KeyCode
+import javafx.scene.input.KeyCodeCombination
 import javafx.scene.layout.Border
 import javafx.scene.layout.BorderStroke
 import javafx.scene.layout.BorderStrokeStyle
@@ -73,9 +75,7 @@ class CatalogueView : View() {
                         }
                     }
                     action {
-                        controller.visualizeFramesSelection(
-                            displayingFieldsView?.selectedItems?.map { it.frame } ?: emptyList()
-                        )
+                        applySelection()
                     }
                 }
                 alignment = Pos.CENTER
@@ -92,6 +92,12 @@ class CatalogueView : View() {
     }
 
     override val root = catalogueNode.also { initializeNodes() }
+
+    init {
+        accelerators[KeyCodeCombination(KeyCode.ENTER)] = {
+            applySelection()
+        }
+    }
 
     fun reinitializeView() {
         reinitializeFields()
@@ -118,6 +124,12 @@ class CatalogueView : View() {
     fun deselectAllFields() {
         displayingFieldsView?.deselectAllItems()
         nonDisplayingFieldsView?.deselectAllItems()
+    }
+
+    private fun applySelection() {
+        controller.visualizeFramesSelection(
+            displayingFieldsView?.selectedItems?.map { it.frame } ?: emptyList()
+        )
     }
 
     private fun reinitializeFields() {

--- a/src/main/kotlin/solve/importer/view/ControlPanel.kt
+++ b/src/main/kotlin/solve/importer/view/ControlPanel.kt
@@ -61,11 +61,7 @@ class ControlPanel : View() {
                     getListOfAlgorithms(frame, listOfKind)
                 }
                 this.text = "Algorithms: " + listOfKind.toStringWithoutBrackets()
-                tooltip(listOfKind.toStringWithoutBrackets()).apply {
-                    style =
-                        "-fx-font-family: ${Style.fontCondensed}; -fx-font-size: ${Style.tooltipFontSize}; " +
-                        "-fx-background-color: #${Style.surfaceColor}; -fx-text-fill: #707070;"
-                }
+                tooltip(listOfKind.toStringWithoutBrackets())
             }
         }
     }

--- a/src/main/kotlin/solve/importer/view/DirectoryPathView.kt
+++ b/src/main/kotlin/solve/importer/view/DirectoryPathView.kt
@@ -45,10 +45,7 @@ class DirectoryPathView : View() {
 
         controller.projectAfterPartialParsing.onChange {
             if (controller.projectAfterPartialParsing.value != null) {
-                tooltip(controller.directoryPath.value).apply {
-                    style = "-fx-font-family: ${Style.fontCondensed}; -fx-font-size: ${Style.tooltipFontSize}; " +
-                        "-fx-background-color: #${Style.surfaceColor}; -fx-text-fill: #707070;"
-                }
+                tooltip(controller.directoryPath.value)
             }
             text = if (it != null) {
                 controller.directoryPath.value
@@ -79,6 +76,7 @@ class DirectoryPathView : View() {
         isFocusTraversable = false
         prefHeight = 31.0
         prefWidth = 98.0
+        tooltip("Ctrl+O")
         action {
             chooseDirectoryAction()
         }

--- a/src/main/kotlin/solve/importer/view/DirectoryPathView.kt
+++ b/src/main/kotlin/solve/importer/view/DirectoryPathView.kt
@@ -4,6 +4,8 @@ import io.github.palexdev.materialfx.effects.DepthLevel
 import io.github.palexdev.materialfx.enums.FloatMode
 import javafx.geometry.Insets
 import javafx.geometry.Pos
+import javafx.scene.input.KeyCode
+import javafx.scene.input.KeyCodeCombination
 import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
@@ -74,11 +76,17 @@ class DirectoryPathView : View() {
         textFill = Color.valueOf(Style.primaryColor)
         alignment = Pos.CENTER
         depthLevel = DepthLevel.LEVEL1
+        isFocusTraversable = false
         prefHeight = 31.0
         prefWidth = 98.0
         action {
-            val dir = directoryChooser.showDialog(currentStage)
-            controller.directoryPath.set(dir?.absolutePath)
+            chooseDirectoryAction()
+        }
+    }
+
+    init {
+        accelerators[KeyCodeCombination(KeyCode.O, KeyCodeCombination.CONTROL_DOWN)] = {
+            chooseDirectoryAction()
         }
     }
 
@@ -114,4 +122,9 @@ class DirectoryPathView : View() {
             }
             separator().apply { visibleWhen { controller.projectAfterPartialParsing.isNotNull } }
         }
+
+    private fun chooseDirectoryAction() {
+        val dir = directoryChooser.showDialog(currentStage)
+        controller.directoryPath.set(dir?.absolutePath)
+    }
 }

--- a/src/main/kotlin/solve/importer/view/ImporterView.kt
+++ b/src/main/kotlin/solve/importer/view/ImporterView.kt
@@ -1,14 +1,15 @@
 package solve.importer.view
 
 import solve.styles.Style
-import tornadofx.View
-import tornadofx.borderpane
+import solve.styles.ToolTipStyle
+import tornadofx.*
 
 class ImporterView : View() {
     override val root = borderpane {
         stylesheets.add("https://fonts.googleapis.com/css2?family=Roboto+Condensed")
         stylesheets.add("https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@700")
         stylesheets.add("https://fonts.googleapis.com/css2?family=Roboto")
+        addStylesheet(ToolTipStyle::class)
 
         style = "-fx-background-color: #${Style.surfaceColor};"
 

--- a/src/main/kotlin/solve/importer/view/ImporterView.kt
+++ b/src/main/kotlin/solve/importer/view/ImporterView.kt
@@ -1,7 +1,7 @@
 package solve.importer.view
 
 import solve.styles.Style
-import solve.styles.ToolTipStyle
+import solve.styles.TooltipStyle
 import tornadofx.*
 
 class ImporterView : View() {
@@ -9,7 +9,7 @@ class ImporterView : View() {
         stylesheets.add("https://fonts.googleapis.com/css2?family=Roboto+Condensed")
         stylesheets.add("https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@700")
         stylesheets.add("https://fonts.googleapis.com/css2?family=Roboto")
-        addStylesheet(ToolTipStyle::class)
+        addStylesheet(TooltipStyle::class)
 
         style = "-fx-background-color: #${Style.surfaceColor};"
 

--- a/src/main/kotlin/solve/importer/view/ProjectTreeView.kt
+++ b/src/main/kotlin/solve/importer/view/ProjectTreeView.kt
@@ -108,11 +108,7 @@ open class ProjectTreeView : View() {
                             item?.errors?.toStringWithoutBrackets()
                         }
                         if (!empty && text.isNotEmpty()) {
-                            tooltip(text).apply {
-                                style =
-                                    "-fx-font-family: ${Style.font}; -fx-font-size: ${Style.tooltipFontSize}; " +
-                                    "-fx-background-color: #${Style.surfaceColor}; -fx-text-fill: #707070;"
-                            }
+                            tooltip(text)
                         }
                     }
                 }

--- a/src/main/kotlin/solve/main/MainView.kt
+++ b/src/main/kotlin/solve/main/MainView.kt
@@ -31,6 +31,7 @@ import solve.sidepanel.content.SidePanelContentView
 import solve.sidepanel.tabs.SidePanelTabsView
 import solve.styles.MFXButtonStyleSheet
 import solve.styles.Style
+import solve.styles.ToolTipStyle
 import solve.utils.MaterialFXDialog
 import solve.utils.createPxBox
 import solve.utils.loadResourcesImage
@@ -72,18 +73,21 @@ class MainView : View() {
     private val leftSidePanelTabs = listOf(
         SidePanelTab(
             ProjectTabName,
-            find<CatalogueView>().root
+            find<CatalogueView>().root,
+            "Ctrl+P"
         )
     )
 
     private val rightSidePanelTabs = listOf(
         SidePanelTab(
             LayersTabName,
-            find<VisualizationSettingsView>().root
+            find<VisualizationSettingsView>().root,
+            "Ctrl+L"
         ),
         SidePanelTab(
             GridTabName,
-            find<GridSettingsView>().root
+            find<GridSettingsView>().root,
+            "Ctrl+G"
         )
     )
 
@@ -101,6 +105,7 @@ class MainView : View() {
         setPrefSize(56.0, 56.0)
         style = "-fx-background-color: #${Style.secondaryColor}; -fx-background-radius: 28;"
         isFocusTraversable = false
+        tooltip("Ctrl+I")
         action {
             importAction()
         }
@@ -158,6 +163,7 @@ class MainView : View() {
     override val root = mainViewBorderPane
 
     init {
+        root.addStylesheet(ToolTipStyle::class)
         accelerators[KeyCodeCombination(KeyCode.I, KeyCombination.CONTROL_DOWN)] = {
             importAction()
         }

--- a/src/main/kotlin/solve/main/MainView.kt
+++ b/src/main/kotlin/solve/main/MainView.kt
@@ -9,6 +9,9 @@ import javafx.geometry.Insets
 import javafx.scene.control.ContentDisplay
 import javafx.scene.image.Image
 import javafx.scene.image.ImageView
+import javafx.scene.input.KeyCode
+import javafx.scene.input.KeyCodeCombination
+import javafx.scene.input.KeyCombination
 import javafx.scene.layout.VBox
 import javafx.scene.shape.Circle
 import solve.catalogue.view.CatalogueView
@@ -43,6 +46,10 @@ class MainView : View() {
         private const val TabsViewTabsParamName = "tabs"
         private const val TabsViewInitialTabParamName = "initialTab"
 
+        const val ProjectTabName = "Project"
+        const val LayersTabName = "Layers"
+        const val GridTabName = "Grid"
+
         private val importIcon = loadResourcesImage(IconsImportFab)
         private val pluginsIcon = loadResourcesImage(IconsPlugins)
         private val settingsIcon = loadResourcesImage(IconsSettings)
@@ -64,18 +71,18 @@ class MainView : View() {
 
     private val leftSidePanelTabs = listOf(
         SidePanelTab(
-            "Project",
+            ProjectTabName,
             find<CatalogueView>().root
         )
     )
 
     private val rightSidePanelTabs = listOf(
         SidePanelTab(
-            "Layers",
+            LayersTabName,
             find<VisualizationSettingsView>().root
         ),
         SidePanelTab(
-            "Grid",
+            GridTabName,
             find<GridSettingsView>().root
         )
     )
@@ -148,6 +155,21 @@ class MainView : View() {
     }
 
     override val root = mainViewBorderPane
+
+    init {
+        accelerators[KeyCodeCombination(KeyCode.I, KeyCombination.CONTROL_DOWN)] = {
+            importAction()
+        }
+        accelerators[KeyCodeCombination(KeyCode.P, KeyCombination.CONTROL_DOWN)] = {
+            leftSidePanelViews.tabsView.selectTab(ProjectTabName)
+        }
+        accelerators[KeyCodeCombination(KeyCode.L, KeyCombination.CONTROL_DOWN)] = {
+            rightSidePanelViews.tabsView.selectTab(LayersTabName)
+        }
+        accelerators[KeyCodeCombination(KeyCode.G, KeyCombination.CONTROL_DOWN)] = {
+            rightSidePanelViews.tabsView.selectTab(GridTabName)
+        }
+    }
 
     private fun createTabButton(text: String, icon: Image?): MFXButton {
         return mfxButton(text) {

--- a/src/main/kotlin/solve/main/MainView.kt
+++ b/src/main/kotlin/solve/main/MainView.kt
@@ -31,7 +31,7 @@ import solve.sidepanel.content.SidePanelContentView
 import solve.sidepanel.tabs.SidePanelTabsView
 import solve.styles.MFXButtonStyleSheet
 import solve.styles.Style
-import solve.styles.ToolTipStyle
+import solve.styles.TooltipStyle
 import solve.utils.MaterialFXDialog
 import solve.utils.createPxBox
 import solve.utils.loadResourcesImage
@@ -163,7 +163,7 @@ class MainView : View() {
     override val root = mainViewBorderPane
 
     init {
-        root.addStylesheet(ToolTipStyle::class)
+        root.addStylesheet(TooltipStyle::class)
         accelerators[KeyCodeCombination(KeyCode.I, KeyCombination.CONTROL_DOWN)] = {
             importAction()
         }

--- a/src/main/kotlin/solve/main/MainView.kt
+++ b/src/main/kotlin/solve/main/MainView.kt
@@ -100,6 +100,7 @@ class MainView : View() {
         graphic = ImageView(importIcon)
         setPrefSize(56.0, 56.0)
         style = "-fx-background-color: #${Style.secondaryColor}; -fx-background-radius: 28;"
+        isFocusTraversable = false
         action {
             importAction()
         }

--- a/src/main/kotlin/solve/scene/view/SceneView.kt
+++ b/src/main/kotlin/solve/scene/view/SceneView.kt
@@ -116,8 +116,6 @@ class SceneView : View() {
 
         currentGrid = grid
         add(grid.node)
-
-        grid.node.requestFocus()
     }
 
     private fun bindPositionProperties(grid: Grid) {

--- a/src/main/kotlin/solve/scene/view/SceneView.kt
+++ b/src/main/kotlin/solve/scene/view/SceneView.kt
@@ -1,6 +1,8 @@
 package solve.scene.view
 
 import javafx.application.Platform
+import javafx.scene.input.KeyCode
+import javafx.scene.input.KeyCodeCombination
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -26,6 +28,7 @@ class SceneView : View() {
     }
 
     init {
+        initKeyboardNavigation()
         addBindings()
     }
 
@@ -113,6 +116,8 @@ class SceneView : View() {
 
         currentGrid = grid
         add(grid.node)
+
+        grid.node.requestFocus()
     }
 
     private fun bindPositionProperties(grid: Grid) {
@@ -156,7 +161,73 @@ class SceneView : View() {
         }
     }
 
+    private fun initKeyboardNavigation() {
+        accelerators[KeyCodeCombination(KeyCode.RIGHT)] = handler@{
+            scrollRight(currentGrid ?: return@handler)
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.KP_RIGHT)] = handler@{
+            scrollRight(currentGrid ?: return@handler)
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.LEFT)] = handler@{
+            scrollLeft(currentGrid ?: return@handler)
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.KP_LEFT)] = handler@{
+            scrollLeft(currentGrid ?: return@handler)
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.UP)] = handler@{
+            scrollUp(currentGrid ?: return@handler)
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.KP_UP)] = handler@{
+            scrollUp(currentGrid ?: return@handler)
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.DOWN)] = handler@{
+            scrollDown(currentGrid ?: return@handler)
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.KP_DOWN)] = handler@{
+            scrollDown(currentGrid ?: return@handler)
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.MINUS)] = handler@{
+            if (currentGrid == null) return@handler
+            zoomOutFromCenter()
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.SUBTRACT)] = handler@{
+            if (currentGrid == null) return@handler
+            zoomOutFromCenter()
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.EQUALS)] = handler@{
+            if (currentGrid == null) return@handler
+            zoomInToCenter()
+        }
+
+        accelerators[KeyCodeCombination(KeyCode.ADD)] = handler@{
+            if (currentGrid == null) return@handler
+            zoomInToCenter()
+        }
+    }
+
+    private fun scrollRight(grid: Grid) = grid.scrollX(grid.xProperty.value + scrollSpeed)
+
+    private fun scrollLeft(grid: Grid) = grid.scrollX(grid.xProperty.value - scrollSpeed)
+
+    private fun scrollUp(grid: Grid) = grid.scrollY(grid.yProperty.value - scrollSpeed)
+
+    private fun scrollDown(grid: Grid) = grid.scrollY(grid.yProperty.value + scrollSpeed)
+    private fun zoomOutFromCenter() = controller.zoomOut(DoublePoint(root.width / 2, root.height / 2))
+
+    private fun zoomInToCenter() = controller.zoomIn(DoublePoint(root.width / 2, root.height / 2))
+
     companion object {
         const val framesMargin = 10.0
+        const val scrollSpeed = 20.0
     }
 }

--- a/src/main/kotlin/solve/sidepanel/SidePanelTab.kt
+++ b/src/main/kotlin/solve/sidepanel/SidePanelTab.kt
@@ -2,4 +2,4 @@ package solve.sidepanel
 
 import javafx.scene.Node
 
-data class SidePanelTab(val name: String, val contentNode: Node)
+data class SidePanelTab(val name: String, val contentNode: Node, val tooltip: String)

--- a/src/main/kotlin/solve/sidepanel/tabs/SidePanelTabsView.kt
+++ b/src/main/kotlin/solve/sidepanel/tabs/SidePanelTabsView.kt
@@ -51,6 +51,7 @@ open class SidePanelTabsView : View() {
                 "-fx-font-family: ${Style.font}; -fx-font-weight:700;" +
                 " -fx-font-size: ${Style.buttonFontSize}; -fx-background-radius: 36"
 
+            isFocusTraversable = false
             setPrefSize(72.0, 72.0)
             usePrefSize = true
 

--- a/src/main/kotlin/solve/sidepanel/tabs/SidePanelTabsView.kt
+++ b/src/main/kotlin/solve/sidepanel/tabs/SidePanelTabsView.kt
@@ -52,6 +52,7 @@ open class SidePanelTabsView : View() {
                 " -fx-font-size: ${Style.buttonFontSize}; -fx-background-radius: 36"
 
             isFocusTraversable = false
+            tooltip(tab.tooltip)
             setPrefSize(72.0, 72.0)
             usePrefSize = true
 

--- a/src/main/kotlin/solve/sidepanel/tabs/SidePanelTabsView.kt
+++ b/src/main/kotlin/solve/sidepanel/tabs/SidePanelTabsView.kt
@@ -35,6 +35,12 @@ open class SidePanelTabsView : View() {
         initializeTabsToggle()
     }
 
+    fun selectTab(name: String) {
+        val tab = tabs.single { it.name == name }
+        val button = tabsToggleButtonsMap[tab] ?: throw RuntimeException("No toggle button for tab")
+        button.fire()
+    }
+
     private fun addTab(tab: SidePanelTab) {
         val tabButton = togglebutton(tab.name, tabsToggleGroup) {
             setPrefSize(Style.navigationRailTabSize, Style.navigationRailTabSize)

--- a/src/main/kotlin/solve/styles/Style.kt
+++ b/src/main/kotlin/solve/styles/Style.kt
@@ -3,11 +3,14 @@ package solve.styles
 import io.github.palexdev.materialfx.controls.MFXButton
 import javafx.scene.control.ToggleButton
 import javafx.scene.shape.Circle
+import tornadofx.*
 
 object Style {
     const val backgroundColour = "EFF0F0"
 
     const val surfaceColor = "FFFFFF"
+
+    const val tooltipColor = "707070"
 
     const val primaryColor = "78909C"
 
@@ -29,7 +32,7 @@ object Style {
 
     const val headerFontSize = "20px"
 
-    const val tooltipFontSize = "12px"
+    val tooltipFontSize = Dimension(12.0, Dimension.LinearUnits.px)
 
     const val buttonStyle =
         "-fx-font-family: 'Roboto Condensed'; -fx-font-size: $buttonFontSize;" +

--- a/src/main/kotlin/solve/styles/TooltipStyle.kt
+++ b/src/main/kotlin/solve/styles/TooltipStyle.kt
@@ -4,7 +4,7 @@ import javafx.scene.text.FontPosture
 import tornadofx.Stylesheet
 import tornadofx.c
 
-class ToolTipStyle : Stylesheet() {
+class TooltipStyle : Stylesheet() {
     init {
         Companion.tooltip {
             fontStyle = FontPosture.REGULAR

--- a/src/main/kotlin/solve/styles/TooltipStyle.kt
+++ b/src/main/kotlin/solve/styles/TooltipStyle.kt
@@ -1,0 +1,17 @@
+package solve.styles
+
+import javafx.scene.text.FontPosture
+import tornadofx.Stylesheet
+import tornadofx.c
+
+class ToolTipStyle : Stylesheet() {
+    init {
+        Companion.tooltip {
+            fontStyle = FontPosture.REGULAR
+            fontFamily = Style.fontCondensed
+            fontSize = Style.tooltipFontSize
+            backgroundColor += c(Style.surfaceColor)
+            textFill = c(Style.tooltipColor)
+        }
+    }
+}


### PR DESCRIPTION
Completed:

- [x] Scene keyboard navigation (zoom and scrolling).
- [x] Application global shortcuts.
- [x] Importer window shortcuts.

Following keyboard actions were added:
1. Arrows and numpad arrows to scroll the scene.
2. +/- and numpad +/- to zoom the scene.
3. Enter to apply selection from the catalog.
4. Ctrl+I to open the importer window.
5. Ctrl+O to open file dialog in the importer window.
6. Enter to close importer window with apply, Esc to close with cancel.
7. Ctrl+G to open grid settings.
8. Ctrl+C to open catalog.
9. Ctrl+L to open layers list.

Example: [imgur](https://imgur.com/a/Ndpdlom).